### PR TITLE
Increase MaxConnections for sshd_worker

### DIFF
--- a/user_data/systemd.tpl
+++ b/user_data/systemd.tpl
@@ -6,6 +6,7 @@ Description=SSH Socket for Per-Connection docker ssh container
 [Socket]
 ListenStream=${bastion_ssh_port}
 Accept=true
+MaxConnections=1024
 
 [Install]
 WantedBy=sockets.target
@@ -31,6 +32,12 @@ systemctl restart sshd.service
 systemctl enable sshd_worker.socket
 systemctl start sshd_worker.socket
 systemctl daemon-reload
+
+cat << EOF > /etc/cron.hourly/sshd_failed_connection_cleanup
+#!/bin/sh
+systemctl reset-failed "sshd_worker@*.service"
+EOF
+chmod 755 /etc/cron.hourly/sshd_failed_connection_cleanup
 
 #set hostname to match dns
 hostnamectl set-hostname ${bastion_host_name}


### PR DESCRIPTION
- Increase MaxConnections for sshd_worker to avoid `systemd[1]: sshd.socket: Too many incoming connections (64)`. The initial parameter is 64, which is not enough: some connections are generated by AWS Network LB checks, and also it might be some random connections from the internet.
- Add Hourly Cron task to remove the failed sshd_worker services, I am not sure if it is a big problem, but they clatter the output of `systemctl`
```
● sshd_worker@105-10.0.27.106:2222-10.0.65.115:62465.service   loaded failed failed    SSH Per-Connection docker ssh container (10.0.65.115:62465)
● sshd_worker@106-10.0.27.106:2222-10.0.65.115:16465.service   loaded failed failed    SSH Per-Connection docker ssh container (10.0.65.115:16465)
● sshd_worker@107-10.0.27.106:2222-66.29.131.100:51636.service loaded failed failed    SSH Per-Connection docker ssh container (66.29.131.100:51636)
● sshd_worker@108-10.0.27.106:2222-10.0.65.115:57806.service   loaded failed failed    SSH Per-Connection docker ssh container (10.0.65.115:57806)
● sshd_worker@109-10.0.27.106:2222-10.0.65.115:8340.service    loaded failed failed    SSH Per-Connection docker ssh container (10.0.65.115:8340)
```